### PR TITLE
Fix image link

### DIFF
--- a/contentmodifier/js/itemparser.js
+++ b/contentmodifier/js/itemparser.js
@@ -36,8 +36,11 @@ function strip(text) {
 }
 
 function fixLink(text) {
-    if (text && text.indexOf('//') == 0) {
-        return 'https:' + text;
+    if (text) {
+        if (text.indexOf('//') == 0) {
+            return 'https:' + text;
+        }
+        return text;
     }
     return null;
 }


### PR DESCRIPTION
Thumbnail is not display. The call to `fixLink` with is supposed to fix link when url is starting with `//` is actually breaking things when the link is already legit.
 
```js
item.pictureUrl = fixLink(pics.attr('data-imgsrc'));
```

```html
<span class="lazyload" style="display:block; width:100%; height:100%;" data-imgSrc="https://img1.leboncoin.fr/ad-thumb/d901e52f21aefcc2ca6c0e9af3dd30e99972a9fa.jpg" data-imgAlt="Etag&egrave;re noire en tissu"></span>
```